### PR TITLE
Tutorial Docs Update/Clean-up

### DIFF
--- a/docs/tutorial/importing-data.md
+++ b/docs/tutorial/importing-data.md
@@ -95,33 +95,33 @@ The cloned folder/tutorial data will be located on the Desktop under the name **
 
 ## Import videos into SLEAP
 
-1. Open a terminal and activate the SLEAP environment by running the following command:
+1. Open a terminal. Then launch the SLEAP GUI by typing this command followed by <kbd>Enter</kbd> or <kbd>Return</kbd>:
 
     ```bash
-    conda activate sleap
+    uv run sleap-label
     ```
 
-2. Open a terminal. Then launch the SLEAP GUI by typing this command followed by <kbd>Enter</kbd> or <kbd>Return</kbd>:
-
-    ```bash
-    sleap-label
-    ```
+    !!! note "If you installed SLEAP with **pip**"
+        Make sure to first activate the SLEAP conda environment:
+        ```bash
+        conda activate sleap
+        ```
 
     ![](../assets/images/tutorial/open-gui.png)
 
-3. Go to **File** → **Add Videos...** to open the file browser.
+2. Go to **File** → **Add Videos...** to open the file browser.
 
     ![](../assets/images/tutorial/add-videos.png)
 
 
-4. **Open** the mice.mp4 from the git cloned folder **sleap-tutorial-data-main**. For future reference, SLEAP currently supports mp4, avi, and h5 files[^1].
+3. **Open** the mice.mp4 from the git cloned folder **sleap-tutorial-data-main**. For future reference, SLEAP currently supports mp4, avi, and h5 files[^1].
 [^1]: SLEAP currently supports mp4, avi, and h5 files. For mp4 and avi files, you’ll be asked whether to import the video as grayscale. For h5 files, you’ll be asked the dataset and whether the video is stored with channels first or last.
 
 
 
     ![](../assets/images/tutorial/import-mice-mp4.png)
 
-5. The video import interface will appear. Click **Import** to finish adding the videos.
+4. The video import interface will appear. Click **Import** to finish adding the videos.
 
     ![](../assets/images/tutorial/import.png)
 
@@ -152,7 +152,7 @@ The final skeleton setup should look like this:
 ![](../assets/images/tutorial/edges.png)
 
 
-You did it! 
+You did it!
 
 [*Next up:* Initial labeling](initial-labeling.md)
 

--- a/docs/tutorial/importing-data.md
+++ b/docs/tutorial/importing-data.md
@@ -107,6 +107,11 @@ The cloned folder/tutorial data will be located on the Desktop under the name **
         conda activate sleap
         ```
 
+        Then you can launch the GUI with:
+        ```bash
+        sleap-label
+        ```
+
     ![](../assets/images/tutorial/open-gui.png)
 
 2. Go to **File** → **Add Videos...** to open the file browser.

--- a/docs/tutorial/initial-labeling.md
+++ b/docs/tutorial/initial-labeling.md
@@ -54,6 +54,7 @@ We **label a frame** by creating an instance for each visible animal.
     !!! tip
         * To quickly move the entire instance, hold <kbd>alt</kbd> (PC) or <kbd>option</kbd> (Mac) while dragging any node of the instance.
         * You can rotate the instance by holding down the <kbd>alt</kbd> (PC) or <kbd>option</kbd> (Mac) while you then click on a node and use the scroll-wheel.
+        * To copy an entire instance, hold <kbd>Win</kbd> (PC) or <kbd>cmd</kbd> (Mac) while clicking any node of the instance.
 
 ## Save the project
 

--- a/docs/tutorial/setup.md
+++ b/docs/tutorial/setup.md
@@ -11,12 +11,18 @@ SLEAP uses deep neural networks to learn how to predict poses from data. Trainin
 
 If you know you have a GPU on your machine or have a [Mac with Apple Silicon](https://support.apple.com/en-us/116943), you can install SLEAP locally and follow along this tutorial.
 
+!!! tip "sleap-nn neural-network backend"
+    The SLEAP GUI can be installed and used independently of the sleap-nn backend for **labeling**. However, for this tutorial it is important that you have sleap-nn installed with the correct **PyTorch and CUDA versions** according to your machine (ex. CPU or GPU).
+
+    To check which PyTorch and CUDA versions you should have installed, see [here](https://nn.sleap.ai/dev/installation/).
+
+
 ## Install SLEAP locally
 
 **See the [main SLEAP installation instructions](../installation.md) for detailed installation instructions.**
 
 If you have either a Linux or Windows laptop with a GPU, or a [Mac with Apple Silicon](https://support.apple.com/en-us/116943), SLEAP will work natively with hardware acceleration.
-
+<!-- 
 1. Make sure that you have [Miniforge](https://github.com/conda-forge/miniforge) installed.
 
     You can also use Miniconda or vanilla Anaconda, but we recommend Miniforge since it
@@ -69,7 +75,7 @@ If you have either a Linux or Windows laptop with a GPU, or a [Mac with Apple Si
 
         ```bash
         mamba create -y -n sleap -c conda-forge -c anaconda -c sleap sleap=1.3.3
-        ```
+        ``` -->
 
 
 [*Next up:* Importing data](importing-data.md)


### PR DESCRIPTION
This pull request updates the SLEAP tutorial documentation to clarify installation requirements, improve the instructions for launching the GUI and importing videos, and add helpful tips for labeling.

**Notes:**
* Added a tip explaining that the SLEAP GUI can be installed and used independently from the `sleap-nn` backend for labeling, but for the tutorial, `sleap-nn` should be installed with the correct PyTorch and CUDA versions, with a link to the relevant installation guide.
* Commented out the explicit `mamba create` command in the setup instructions to avoid potential confusion and to direct users to `uv` installation instructions instead.
* Added a tip describing how to copy an entire instance in the labeling interface by holding <kbd>Win</kbd> (PC) or <kbd>cmd</kbd> (Mac) while clicking any node.