### PR TITLE
Docs UV Installation Fix

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,23 +21,23 @@ SLEAP is an open-source deep-learning based framework for multi-animal pose trac
 
 - Flexible developer API for building integrated apps and customization
 
-- Two independent backends-- [*sleap-nn*](https://nn.sleap.ai) and [*sleap-io*](https://io.sleap.ai) for training/infernece pipelines & handling SLEAP files respectively
+- Two independent backends-- [`sleap-nn`](https://nn.sleap.ai) and [`sleap-io`](https://io.sleap.ai) for training/infernece pipelines & handling SLEAP files respectively
 
 <!-- # TODO: Update training time taken DS -->
 
-!!! tip "sleap-nn backend"
-    The SLEAP GUI can be installed and used independently of the sleap-nn backend for **labeling**. However, for training and inference workflows, it is important that you have sleap-nn installed with the correct **PyTorch and CUDA versions** according to your machine (ex. CPU or GPU).
+!!! tip "`sleap-nn` Backend"
+    The SLEAP GUI can be installed and used independently of the `sleap-nn` backend for **labeling**. However, for training and inference workflows, it is important that you have sleap-nn installed with the correct **PyTorch and CUDA versions** according to your machine (ex. CPU or GPU).
     
-    Learn more about sleap-nn [here](https://nn.sleap.ai).
+    Learn more about `sleap-nn` [here](https://nn.sleap.ai).
 
-!!! tip "sleap-io backend"
-    The SLEAP GUI can be installed and used independently of the sleap-io backend for **labeling**. However, for working with SLEAP files directly from a CLI, it is best to use sleap-io.
+!!! tip "`sleap-io` Backend"
+    For working with SLEAP files **directly from a CLI**, it is best to use `sleap-io`.
     
-    Learn more about sleap-nn [here](https://io.sleap.ai).
+    Learn more about `sleap-io` [here](https://io.sleap.ai).
 
 ## Get some SLEAP
 
-SLEAP is installed as a Python package. We strongly recommend using [Miniconda](https://www.anaconda.com/docs/getting-started/miniconda/main) to install SLEAP in its own environment.
+SLEAP is installed as a Python package. We strongly recommend using [uv](https://docs.astral.sh/uv/) or [Miniconda](https://www.anaconda.com/docs/getting-started/miniconda/main) to install SLEAP in its own environment.
 
 You can find the latest version of SLEAP in the [Releases](https://github.com/talmolab/sleap/releases) page.
 
@@ -45,21 +45,33 @@ You can find the latest version of SLEAP in the [Releases](https://github.com/ta
     This documentation is for the **latest version of SLEAP**.  
     If you are using **SLEAP version 1.4.1 or earlier**, please visit the [legacy documentation](http://legacy.sleap.ai).
 
-### Quick install
+### Quick start
 
-**`uv` (any OS):**
+!!! tip "Sample with `uvx`"
+    Note that opening SLEAP w/ `uvx` will **not** install SLEAP onto your system, it will only 'invoke' SLEAP.
 
-=== "Windows/Linux/GPU"
-    ``` bash
-    uv pip install sleap --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu128
+**`uvx` (any OS):**
+
+=== "Windows/Linux (CUDA 12.8)"
+    ```bash
+    uvx --from "sleap[nn]" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu128 sleap-label
+    ```
+    !!! info "Other CUDA versions"
+        For other CUDA version installation options, see [sleap-nn installation](https://nn.sleap.ai/dev/installation/#platform-specific-installation) for other supported versions.
+
+=== "macOS/CPU Only"
+    ```bash
+    uvx --from "sleap[nn]" sleap-label
     ```
 
-=== "MacOS/CPU only"
-    ``` bash
-    uv pip install sleap --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cpu
+=== "SLEAP GUI Only"
+    ```bash
+    uvx --from "sleap" sleap-label
     ```
+    !!! warning "GUI <u>ONLY</u>"
+        Installing this version of SLEAP will **NOT** include any training/inference capabilities, as it will not include the sleap-nn backend. This should primarily be used for **labeling**.
 
-**`pip` (any OS except Apple silicon)**:
+**`pip` (any OS)**:
 
 ```
 pip install sleap

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,29 @@
     If you are using **SLEAP version 1.4.1 or earlier**, please visit the [legacy documentation](http://legacy.sleap.ai).
 
 
-SLEAP can be installed via [uv](https://docs.astral.sh/uv/), an ultra-fast Python package and project manager supported on Windows, Linux, and Mac OS. 
+SLEAP can be installed as a Python package on Windows, Linux, and Mac OS. For a quick sample using [`uv`](https://docs.astral.sh/uv/)- an ultra-fast Python package and project manager, see below (no installation required!):
+
+=== "Windows/Linux (CUDA 12.8)"
+    ```bash
+    uvx --from "sleap[nn]" --index-url https://pypi.org/simple --extra-index-url https://download.pytorch.org/whl/cu128 sleap-label
+    ```
+    !!! info "Other CUDA versions"
+        For other CUDA version installation options, see [sleap-nn installation](https://nn.sleap.ai/dev/installation/#platform-specific-installation) for other supported versions.
+
+=== "macOS/CPU Only"
+    ```bash
+    uvx --from "sleap[nn]" sleap-label
+    ```
+
+=== "SLEAP GUI Only"
+    ```bash
+    uvx --from "sleap" sleap-label
+    ```
+    !!! warning "GUI <u>ONLY</u>"
+        Installing this version of SLEAP will **NOT** include any training/inference capabilities, as it will not include the sleap-nn backend. This should primarily be used for **labeling**.
+
+!!! tip "Sample with `uvx`"
+    Note that opening SLEAP w/ `uvx` will **not** install SLEAP onto your system, it will only 'invoke' SLEAP.
 
 For more in-depth installation instructions, see the [installation methods](#installation-methods). The newest version of SLEAP can always be found in the [Releases page](https://github.com/talmolab/sleap/releases).
 
@@ -41,13 +63,13 @@ For more in-depth installation instructions, see the [installation methods](#ins
 **Prerequisites:** Python 3.11+ (required for all installation methods)
 
 !!! tip "Choose Your Installation Method"
-    - **[Installation with uv tool install](#installation-with-uv-tool-install)**: Use `uv tool install` to create a virtual environment in the uv tool directory. (Installation needed, preferred)
+    - **[Installation with uv tool install](#installation-with-uv-tool-install)**: Use `uv tool install` to create a virtual environment for SLEAP to run from (Installation needed, **strongly recommended**)
     - **[Installation with pip](#installation-with-pip)**: Use `pip` to install from pypi in a conda env. (Recommended to use with a conda env)
     - **[Installation from source](#development-setup-with-uv)**: Use `uv sync` to install from source. (For developmental purposes)
 
 ## Installation with uv tool install
 
-`uv tool install` automatically installs sleap-nn and creates the `sleap-label` tool inside a virtual environement located inside the uv tool directory. This means that using `uvx` to run this tool will use this installed version. Installing via `uv tool install` also has the advantage of not loading dependencies each time, unlike `uvx` installation alone.
+`uv tool install` automatically installs and creates the `sleap-label` tool inside a virtual environment located inside the [uv tool directory](https://docs.astral.sh/uv/concepts/tools/#tools-directory). This means that running this tool will use this installed version.
 
 !!! warning "First Time Setup"
     Install [`uv`](https://github.com/astral-sh/uv) first - an ultra-fast Python package manager:
@@ -63,21 +85,29 @@ For more in-depth installation instructions, see the [installation methods](#ins
 
 === "Windows/Linux (CUDA 12.8)"
     ```bash
-    uv tool install "sleap[nn-gpu]"
+    uv tool install "sleap[nn]" --index-url https://pypi.org/simple --extra-index-url htpps://download.pytorch.org/whl/cu128 
     ```
-    !!! note "Other CUDA versions"
+    !!! info "Other CUDA versions"
         For other CUDA version installation options, see [sleap-nn installation](https://nn.sleap.ai/dev/installation/#platform-specific-installation) for other supported versions.
 
 === "macOS/CPU Only"
     ```bash
-    uv tool install "sleap[nn-cpu]"
+    uv tool install "sleap[nn]"
     ```
+
+=== "SLEAP GUI Only"
+    ```bash
+    uv tool install "sleap"
+    ```
+    !!! warning "GUI <u>ONLY</u>"
+        Installing this version of SLEAP will **NOT** include any training/inference capabilities, as it will not include the sleap-nn backend. This should primarily be used for **labeling**.
+
 
 !!! tip "How uv tool install Works"
     - **Automatic Installation**: Downloads and installs SLEAP with dependencies
-    - **Isolated Environment**: Each run w/ uvx after installation runs in a clean, separated virtual environment
-    - **No Conflicts**: Won't interfere with your existing Python packages
-    - **Uses recent pkgs**: Uses the latest version from PyPI
+    - **Isolated Environment**: Each run after installation runs in a clean, separated virtual environment
+    - **No Conflicts**: Won't interfere with your existing Python packages/dependencies
+    - **Uses Recent Packages**: Uses the latest version from PyPI
 
 ---
 
@@ -85,7 +115,7 @@ For more in-depth installation instructions, see the [installation methods](#ins
 
 **Package Manager**
 
-SLEAP requires many complex dependencies, so we **strongly** recommend using a package manager such as [Miniforge](https://github.com/conda-forge/miniforge) or [Miniconda](https://docs.anaconda.com/free/miniconda/) to install SLEAP in its own isolated environment.
+SLEAP requires many complex dependencies, so we **strongly** recommend using a package manager such as [Miniforge](https://github.com/conda-forge/miniforge) or [Miniconda](https://docs.anaconda.com/free/miniconda/) to install SLEAP in its own isolated environment, if not using `uv`.
 
 !!! note
     If you already have Anaconda on your computer (and it is an [older installation](https://conda.org/blog/2023-11-06-conda-23-10-0-release/)), then make sure to [set the solver to `libmamba`](https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community) in the `base` environment.
@@ -101,7 +131,7 @@ SLEAP requires many complex dependencies, so we **strongly** recommend using a p
 
 If you don't have a `conda` package manager installation, here are some quick install options:
 
-### Miniforge (recommended)
+### Miniforge
 
 Miniforge is a minimal installer for conda that includes the `conda` package manager and is maintained by the [conda-forge](https://conda-forge.org) community. The only difference between Miniforge and Miniconda is that Miniforge uses the `conda-forge` channel by default, which provides a much wider selection of community-maintained packages.
 
@@ -180,7 +210,7 @@ SLEAP can be installed with pip via `pip package`. See below.
         !!! note
             - Requires Python 3.11+
 
-        Although you do not need Miniconda installed to perform a `pip install`, we recommend [installing Miniconda](https://docs.anaconda.com/free/miniconda/) to create a new environment where we can isolate the `pip install`. Alternatively, you can use a venv if you have an existing Python 3.11+ installation. If you are working on **Google Colab**, skip to step 3 to perform the `pip install` without using a conda environment.
+        Although you do not need Miniconda installed to perform a `pip install`, we recommend [installing Miniconda](https://docs.anaconda.com/free/miniconda/) to create a new environment where we can isolate the `pip install`. Alternatively, you can use a virtual environment (venv) if you have an existing Python 3.11+ installation. If you are working on **Google Colab**, skip to step 3 to perform the `pip install` without using a conda environment.
 
         1. Otherwise, create a new conda environment where we will `pip install sleap`:
 
@@ -198,14 +228,19 @@ SLEAP can be installed with pip via `pip package`. See below.
 
         3. Finally, we can perform the `pip install`:
 
-            === "NVIDIA GPU (CUDA 12.8)"
+            === "Windows/Linux (CUDA 12.8)"
                 ```bash
                 pip install sleap[nn-gpu]
                 ```
 
-            === "CPU"
+            === "macOS/CPU Only"
                 ```bash
                 pip install sleap[nn-cpu]
+                ```
+
+            === "SLEAP GUI Only"
+                ```bash
+                pip install sleap
                 ```
 
             !!! note
@@ -214,15 +249,15 @@ SLEAP can be installed with pip via `pip package`. See below.
                 - **dev**: This installs all *jupyter* dependencies and developement tools for testing and building docs.
                 - **docs**: This installs all *docs*-related dependencies (ex. mkdocs).
                 - **nn-cpu**: This installs sleap-nn with torch-cpu.
-                - **nn-gpu**: This installs sleap-nn with torch-cuda128
+                - **nn-gpu**: This installs sleap-nn with torch-cuda128.
                 - **jupyter**: This installs all *pypi* and jupyter lab dependencies.
 
 ## Development Setup with uv
 
 For contributing to sleap-nn or development workflows.
 
-!!! info "uv sync"
-    `uv sync` creates a `.venv` (virtual environment) inside your current working directory. This environment is only active within that directory and can't be directly accessed from outside. To use all installed packages, you must run commands with `uv run` (e.g., `uv run sleap-label ...` or `uv run pytest ...`).
+!!! info "`uv sync` and Running With `uv run`"
+    `uv sync` creates a `.venv` (virtual environment) inside your current working directory. This environment is only active within that directory and can't be directly accessed from outside. To use all installed packages, **you must run commands with `uv run`** (e.g., `uv run sleap-label ...` or `uv run pytest ...`).
 
 **1. Clone the Repository**
 
@@ -245,8 +280,14 @@ cd sleap
 
 **3. Install Dependencies**
     ```bash
-    uv sync --all-extras
+    uv sync
     ```
+
+Additionally, if using CUDA 12.8 w/ `sleap-nn` backend on Windows/Linux (CUDA 12.8):
+
+```bash
+uv pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128 --reinstall
+```
 
 **4. Verify Development Setup**
 


### PR DESCRIPTION
This pull request updates the SLEAP documentation to clarify `uv` installation options, including `uxv`, `uv tool install`, and `uv sync` . The changes focus on highlighting the use of the `uv` tool, and clearly distinguishing between the SLEAP GUI and training/inference backends.

**Notes:**

- Added clear, step-by-step instructions for installing SLEAP using the `uv` tool, including new sections for quick sampling with `uvx`, and explicit options for Windows/Linux (CUDA 12.8), macOS/CPU only, and GUI-only installations. Warnings and tips clarify the difference between invoking and installing SLEAP, and highlight that the GUI-only version does not support training/inference. [[1]](diffhunk://#diff-b4d68dc855d0f9476d3f2ee343853bd21bf82ea9960d0cf06661baa244439dd6L24-R74) [[2]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L8-R30) [[3]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L44-R72) [[4]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L66-R118)
- Updated pip installation instructions to match the new backend structure, with clear separation of install commands for different platforms and explicit mention of the available extras. 
- Added a GUI-only pip install option.
- Improved descriptions of the `sleap-nn` and `sleap-io` backends, using consistent formatting and clarifying their roles. Updated tips to better explain backend independence and usage scenarios.
- Clarified the distinction between virtual environments created by `uv tool install`, `uvx`, and standard pip/conda environments, and improved recommendations for environment isolation. [[1]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L44-R72) [[2]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L104-R134) [[3]](diffhunk://#diff-8b042e3f94ca5c59a7cd990b950aec0073ea84fe811e7b22be51158d7b180d56L183-R213)
- Updated the development setup section to clarify the use of `uv sync` and `uv run`, and added explicit instructions for installing CUDA dependencies when developing with the `sleap-nn` backend.